### PR TITLE
Support multiple `role_path` entries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,5 @@ install:
   - go get github.com/fatih/color
 
 script:
+  - go test -v -p 1 ./logger ./commands ./utils ./
   - go build -o playwright main.go

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,13 @@ fmt:
 	cd $(BUILD_PATH) && go fmt
 	cd $(BUILD_PATH)/commands && go fmt
 	cd $(BUILD_PATH)/utils && go fmt
-	cd $(BUILD_PATH)/log && go fmt
+	cd $(BUILD_PATH)/logger && go fmt
+
+test:
+	cd $(BUILD_PATH) && go test -v
+	cd $(BUILD_PATH)/commands && go test -v
+	cd $(BUILD_PATH)/utils && go test -v
+	cd $(BUILD_PATH)/logger && go test -v
 
 install-native: build
 	cd $(BUILD_PATH) && go install
@@ -25,4 +31,4 @@ install-native: build
 install: build
 	cp playwright /usr/local/bin/playwright
 
-.PHONY: build configure fmt install
+.PHONY: build configure fmt install install-native test

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,10 @@ BUILD_ROOT_PATH=$(GO_PATH)/src/com.github/Axblade
 BUILD_PATH=$(BUILD_ROOT_PATH)/playwright
 REPO_PATH=$(CURDIR)
 
+GO=go
+GO_FMT=$(GO) fmt
+GO_TEST=$(GO) test -v -p 1
+
 build:
 	cd $(BUILD_PATH) && go build -o playwright main.go
 
@@ -14,16 +18,16 @@ configure:
 	cd $(BUILD_PATH) && glide install
 
 fmt:
-	cd $(BUILD_PATH) && go fmt
-	cd $(BUILD_PATH)/commands && go fmt
-	cd $(BUILD_PATH)/utils && go fmt
-	cd $(BUILD_PATH)/logger && go fmt
+	cd $(BUILD_PATH) && $(GO_FMT)
+	cd $(BUILD_PATH)/commands && $(GO_FMT)
+	cd $(BUILD_PATH)/utils && $(GO_FMT)
+	cd $(BUILD_PATH)/logger && $(GO_FMT)
 
 test:
-	cd $(BUILD_PATH) && go test -v
-	cd $(BUILD_PATH)/commands && go test -v
-	cd $(BUILD_PATH)/utils && go test -v
-	cd $(BUILD_PATH)/logger && go test -v
+	cd $(BUILD_PATH) && $(GO_TEST)
+	cd $(BUILD_PATH)/commands && $(GO_TEST)
+	cd $(BUILD_PATH)/utils && $(GO_TEST)
+	cd $(BUILD_PATH)/logger && $(GO_TEST)
 
 install-native: build
 	cd $(BUILD_PATH) && go install

--- a/commands/command.go
+++ b/commands/command.go
@@ -30,6 +30,7 @@ var (
 	ANSIBLE_CONFIG     = "./ansible.cfg"
 	ANSIBLE_CONFIG_DOT = "./.ansible.cfg"
 	ANSIBLE_CONFIG_OS  = "/etc/ansible/ansible.cfg"
+	ANSIBLE_ROLES_PATH = "ANSIBLE_ROLES_PATH"
 )
 
 // SelectFolders returns an array of folder names
@@ -63,6 +64,17 @@ func (command *Command) SelectFolders() []string {
 // - from ansible configuration file if it is set
 // - otherwise returns current directory followed by 'roles'
 func (command *Command) ReadRolesPath() (rolesPath string, err error) {
+	envRolesPath := os.Getenv(ANSIBLE_ROLES_PATH)
+
+	if envRolesPath != "" {
+		return envRolesPath, nil
+	}
+
+	return command.readRolesPathFromConfig()
+}
+
+// readRolesPathFromConfig - reads roles path from ansible config file
+func (command *Command) readRolesPathFromConfig() (rolesPath string, err error) {
 	path, err := command.ansibleConfigPath()
 	if err != nil {
 		return "", errors.New("Cannot find Ansible configuration file")

--- a/commands/command.go
+++ b/commands/command.go
@@ -130,6 +130,10 @@ func (command *Command) ansibleConfigPath() (path string, err error) {
 	return "", errors.New("Ansible config not found")
 }
 
+// availableRolesPath parses roles_path string into a set of roles paths
+// roles_path='' is parsed into empty array
+// roles_path=/something is parsed into array with one element '/something'
+// roles_path=/something:/something-else is parsed into array of strings delimited by a ':'
 func availableRolesPath(rolesPaths string) []string {
 	options := strings.TrimSpace(strings.Split(rolesPaths, "=")[1])
 

--- a/commands/command_test.go
+++ b/commands/command_test.go
@@ -1,0 +1,34 @@
+package commands
+
+import (
+	"testing"
+	"reflect"
+	"fmt"
+)
+
+func TestAvailableRolesPathWithSingleInput(t *testing.T) {
+	first := "/path/to/roles"
+	input := "roles_path=" + first
+
+	result := availableRolesPath(input)
+
+	expected := []string{ first }
+	if !reflect.DeepEqual(result, expected) {
+		message := fmt.Sprintf("Function returned wrong array, %v, expected: %v", result, expected)
+		t.Error(message)
+	}
+}
+
+func TestAvailableRolesPathWithMultipleInput(t *testing.T) {
+	first := "/path/to/roles"
+	second := "/other/path/to/roles"
+	input := "roles_path=" + first + ":" + second
+
+	result := availableRolesPath(input)
+
+	expected := []string{ first, second }
+	if !reflect.DeepEqual(result, expected) {
+		message := fmt.Sprintf("Function returned wrong array, %v, expected: %v", result, expected)
+		t.Error(message)
+	}
+}

--- a/commands/command_test.go
+++ b/commands/command_test.go
@@ -1,9 +1,9 @@
 package commands
 
 import (
-	"testing"
-	"reflect"
 	"fmt"
+	"reflect"
+	"testing"
 )
 
 func TestAvailableRolesPathWithSingleInput(t *testing.T) {
@@ -12,7 +12,7 @@ func TestAvailableRolesPathWithSingleInput(t *testing.T) {
 
 	result := availableRolesPath(input)
 
-	expected := []string{ first }
+	expected := []string{first}
 	if !reflect.DeepEqual(result, expected) {
 		message := fmt.Sprintf("Function returned wrong array, %v, expected: %v", result, expected)
 		t.Error(message)
@@ -26,7 +26,7 @@ func TestAvailableRolesPathWithMultipleInput(t *testing.T) {
 
 	result := availableRolesPath(input)
 
-	expected := []string{ first, second }
+	expected := []string{first, second}
 	if !reflect.DeepEqual(result, expected) {
 		message := fmt.Sprintf("Function returned wrong array, %v, expected: %v", result, expected)
 		t.Error(message)

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 35c1ac790bd175ea5a3fe8b42e1e5eb86acad0523cd819f45d8c59c4d8e1ad64
-updated: 2017-08-12T14:22:26.467230962+03:00
+updated: 2017-08-13T21:14:43.997007577+03:00
 imports:
 - name: github.com/alecthomas/template
   version: a0175ee3bccc567396460bf5acd36800cb10c49c

--- a/glide.lock
+++ b/glide.lock
@@ -1,0 +1,31 @@
+hash: 35c1ac790bd175ea5a3fe8b42e1e5eb86acad0523cd819f45d8c59c4d8e1ad64
+updated: 2017-08-12T14:22:26.467230962+03:00
+imports:
+- name: github.com/alecthomas/template
+  version: a0175ee3bccc567396460bf5acd36800cb10c49c
+  subpackages:
+  - parse
+- name: github.com/alecthomas/units
+  version: 2efee857e7cfd4f3d0138cc3cbb1b4966962b93a
+- name: github.com/Axblade/playwright
+  version: 5c07eb18537984182a77d10fa97ea753d7534760
+  subpackages:
+  - commands
+  - logger
+  - utils
+- name: github.com/fatih/color
+  version: 9131ab34cf20d2f6d83fdc67168a5430d1c7dc23
+- name: github.com/mattn/go-colorable
+  version: 5411d3eea5978e6cdc258b30de592b60df6aba96
+  repo: https://github.com/mattn/go-colorable
+- name: github.com/mattn/go-isatty
+  version: 57fdcb988a5c543893cc61bce354a6e24ab70022
+  repo: https://github.com/mattn/go-isatty
+- name: golang.org/x/sys
+  version: e24f485414aeafb646f6fca458b0bf869c0880a1
+  repo: https://go.googlesource.com/sys
+  subpackages:
+  - unix
+- name: gopkg.in/alecthomas/kingpin.v2
+  version: 1087e65c9441605df944fb12c33f0fe7072d18ca
+testImports: []

--- a/main.go
+++ b/main.go
@@ -48,8 +48,6 @@ func main() {
 		err = fmt.Errorf("Nothing was called, check --help command.\n")
 	}
 
-	logger.LogWarning("WTF?!")
-
 	if err == nil {
 		logger.LogSuccess(success)
 	} else {


### PR DESCRIPTION
Ansible config file can contain several roles lookup directories:
```
roles_path = /opt/mysite/roles:/opt/othersite/roles
```

- [x] allow overriding `roles_path` with `ANSIBLE_ROLES_PATH` variable
- [x] parse roles path
- [ ] if multiple entries found, allow user to select 